### PR TITLE
Update plugin and Yeoman generator to 0.21.0, add more recent components from Octant

### DIFF
--- a/plugin/components/accordion.ts
+++ b/plugin/components/accordion.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// GENERATED: do not edit!
+
+import { ComponentFactory, FactoryMetadata } from './component-factory';
+import { Component } from './component';
+
+export interface AccordionConfig {
+  rows: {
+    title: string;
+    content: Component<any>;
+  }[];
+  allowMultipleExpanded: boolean;
+}
+
+interface AccordionParameters {
+  rows: {
+    title: string;
+    content: Component<any>;
+  }[];
+  allowMultipleExpanded: boolean;
+  factoryMetadata?: FactoryMetadata;
+}
+
+export class AccordionFactory implements ComponentFactory<AccordionConfig> {
+  private readonly rows: {
+    title: string;
+    content: Component<any>;
+  }[];
+  private readonly allowMultipleExpanded: boolean;
+  private readonly factoryMetadata: FactoryMetadata | undefined;
+
+  constructor({
+    rows,
+    allowMultipleExpanded,
+    factoryMetadata,
+  }: AccordionParameters) {
+    this.rows = rows;
+    this.allowMultipleExpanded = allowMultipleExpanded;
+    this.factoryMetadata = factoryMetadata;
+  }
+
+  toComponent(): Component<AccordionConfig> {
+    return {
+      metadata: {
+        type: 'accordion',
+        ...this.factoryMetadata,
+      },
+      config: {
+        rows: this.rows,
+        allowMultipleExpanded: this.allowMultipleExpanded,
+      },
+    };
+  }
+}

--- a/plugin/components/button-group.ts
+++ b/plugin/components/button-group.ts
@@ -8,41 +8,19 @@
 import { ComponentFactory, FactoryMetadata } from './component-factory';
 import { Component } from './component';
 
+import { ButtonConfig } from './button';
+
 export interface ButtonGroupConfig {
-  buttons: {
-    name: string;
-    payload: { [key: string]: any };
-    confirmation?: {
-      title: string;
-      body: string;
-    };
-    modal?: Component<any>;
-  }[];
+  buttons: Component<ButtonConfig>[];
 }
 
 interface ButtonGroupParameters {
-  buttons: {
-    name: string;
-    payload: { [key: string]: any };
-    confirmation?: {
-      title: string;
-      body: string;
-    };
-    modal?: Component<any>;
-  }[];
+  buttons: Component<ButtonConfig>[];
   factoryMetadata?: FactoryMetadata;
 }
 
 export class ButtonGroupFactory implements ComponentFactory<ButtonGroupConfig> {
-  private readonly buttons: {
-    name: string;
-    payload: { [key: string]: any };
-    confirmation?: {
-      title: string;
-      body: string;
-    };
-    modal?: Component<any>;
-  }[];
+  private readonly buttons: Component<ButtonConfig>[];
   private readonly factoryMetadata: FactoryMetadata | undefined;
 
   constructor({ buttons, factoryMetadata }: ButtonGroupParameters) {

--- a/plugin/components/button.ts
+++ b/plugin/components/button.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// GENERATED: do not edit!
+
+import { ComponentFactory, FactoryMetadata } from './component-factory';
+import { Component } from './component';
+
+export interface ButtonConfig {
+  name: string;
+  payload: { [key: string]: any };
+  confirmation?: {
+    title: string;
+    body: string;
+  };
+  modal?: Component<any>;
+  status?: string;
+  size?: string;
+  style?: string;
+}
+
+export interface ButtonOptions {
+  confirmation?: {
+    title: string;
+    body: string;
+  };
+  modal?: Component<any>;
+  status?: string;
+  size?: string;
+  style?: string;
+}
+
+interface ButtonParameters {
+  name: string;
+  payload: { [key: string]: any };
+  options?: ButtonOptions;
+  factoryMetadata?: FactoryMetadata;
+}
+
+export class ButtonFactory implements ComponentFactory<ButtonConfig> {
+  private readonly name: string;
+  private readonly payload: { [key: string]: any };
+  private readonly confirmation:
+    | {
+        title: string;
+        body: string;
+      }
+    | undefined;
+  private readonly modal: Component<any> | undefined;
+  private readonly status: string | undefined;
+  private readonly size: string | undefined;
+  private readonly style: string | undefined;
+  private readonly factoryMetadata: FactoryMetadata | undefined;
+
+  constructor({ name, payload, options, factoryMetadata }: ButtonParameters) {
+    this.name = name;
+    this.payload = payload;
+    this.factoryMetadata = factoryMetadata;
+
+    if (options) {
+      this.confirmation = options.confirmation;
+      this.modal = options.modal;
+      this.status = options.status;
+      this.size = options.size;
+      this.style = options.style;
+    }
+  }
+
+  toComponent(): Component<ButtonConfig> {
+    return {
+      metadata: {
+        type: 'button',
+        ...this.factoryMetadata,
+      },
+      config: {
+        name: this.name,
+        payload: this.payload,
+
+        ...(this.confirmation && { confirmation: this.confirmation }),
+        ...(this.modal && { modal: this.modal }),
+        ...(this.status && { status: this.status }),
+        ...(this.size && { size: this.size }),
+        ...(this.style && { style: this.style }),
+      },
+    };
+  }
+}

--- a/plugin/components/card.ts
+++ b/plugin/components/card.ts
@@ -9,6 +9,7 @@ import { ComponentFactory, FactoryMetadata } from './component-factory';
 import { Component } from './component';
 
 import { ButtonGroupConfig } from './button-group';
+import { FormFieldConfig } from './form-field';
 
 export interface CardConfig {
   body: Component<any>;
@@ -16,7 +17,7 @@ export interface CardConfig {
     name: string;
     title: string;
     form: {
-      fields: any[];
+      fields: Component<FormFieldConfig>[];
       action?: string;
     };
     modal: boolean;
@@ -35,7 +36,7 @@ export interface CardOptions {
     name: string;
     title: string;
     form: {
-      fields: any[];
+      fields: Component<FormFieldConfig>[];
       action?: string;
     };
     modal: boolean;
@@ -62,7 +63,7 @@ export class CardFactory implements ComponentFactory<CardConfig> {
         name: string;
         title: string;
         form: {
-          fields: any[];
+          fields: Component<FormFieldConfig>[];
           action?: string;
         };
         modal: boolean;

--- a/plugin/components/card.ts
+++ b/plugin/components/card.ts
@@ -8,6 +8,8 @@
 import { ComponentFactory, FactoryMetadata } from './component-factory';
 import { Component } from './component';
 
+import { ButtonGroupConfig } from './button-group';
+
 export interface CardConfig {
   body: Component<any>;
   actions?: {
@@ -20,8 +22,11 @@ export interface CardConfig {
     modal: boolean;
   }[];
   alert?: {
+    status: string;
     type: string;
     message: string;
+    closable: boolean;
+    buttonGroup: Component<ButtonGroupConfig>;
   };
 }
 
@@ -36,8 +41,11 @@ export interface CardOptions {
     modal: boolean;
   }[];
   alert?: {
+    status: string;
     type: string;
     message: string;
+    closable: boolean;
+    buttonGroup: Component<ButtonGroupConfig>;
   };
 }
 
@@ -62,8 +70,11 @@ export class CardFactory implements ComponentFactory<CardConfig> {
     | undefined;
   private readonly alert:
     | {
+        status: string;
         type: string;
         message: string;
+        closable: boolean;
+        buttonGroup: Component<ButtonGroupConfig>;
       }
     | undefined;
   private readonly factoryMetadata: FactoryMetadata | undefined;

--- a/plugin/components/expandable-row-detail.ts
+++ b/plugin/components/expandable-row-detail.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// GENERATED: do not edit!
+
+import { ComponentFactory, FactoryMetadata } from './component-factory';
+import { Component } from './component';
+
+export interface ExpandableRowDetailConfig {
+  replace: boolean;
+  body: Component<any>[];
+}
+
+interface ExpandableRowDetailParameters {
+  replace: boolean;
+  body: Component<any>[];
+  factoryMetadata?: FactoryMetadata;
+}
+
+export class ExpandableRowDetailFactory
+  implements ComponentFactory<ExpandableRowDetailConfig>
+{
+  private readonly replace: boolean;
+  private readonly body: Component<any>[];
+  private readonly factoryMetadata: FactoryMetadata | undefined;
+
+  constructor({
+    replace,
+    body,
+    factoryMetadata,
+  }: ExpandableRowDetailParameters) {
+    this.replace = replace;
+    this.body = body;
+    this.factoryMetadata = factoryMetadata;
+  }
+
+  toComponent(): Component<ExpandableRowDetailConfig> {
+    return {
+      metadata: {
+        type: 'expandableRowDetail',
+        ...this.factoryMetadata,
+      },
+      config: {
+        replace: this.replace,
+        body: this.body,
+      },
+    };
+  }
+}

--- a/plugin/components/expression-selector.ts
+++ b/plugin/components/expression-selector.ts
@@ -22,7 +22,8 @@ interface ExpressionSelectorParameters {
 }
 
 export class ExpressionSelectorFactory
-  implements ComponentFactory<ExpressionSelectorConfig> {
+  implements ComponentFactory<ExpressionSelectorConfig>
+{
   private readonly key: string;
   private readonly operator: string;
   private readonly values: string[];

--- a/plugin/components/flexlayout.ts
+++ b/plugin/components/flexlayout.ts
@@ -16,6 +16,13 @@ export interface FlexLayoutConfig {
     view?: Component<any>;
   }[][];
   buttonGroup?: Component<ButtonGroupConfig>;
+  alert?: {
+    status: string;
+    type: string;
+    message: string;
+    closable: boolean;
+    buttonGroup: Component<ButtonGroupConfig>;
+  };
 }
 
 export interface FlexLayoutOptions {
@@ -24,6 +31,13 @@ export interface FlexLayoutOptions {
     view?: Component<any>;
   }[][];
   buttonGroup?: Component<ButtonGroupConfig>;
+  alert?: {
+    status: string;
+    type: string;
+    message: string;
+    closable: boolean;
+    buttonGroup: Component<ButtonGroupConfig>;
+  };
 }
 
 interface FlexLayoutParameters {
@@ -39,6 +53,15 @@ export class FlexLayoutFactory implements ComponentFactory<FlexLayoutConfig> {
       }[][]
     | undefined;
   private readonly buttonGroup: Component<ButtonGroupConfig> | undefined;
+  private readonly alert:
+    | {
+        status: string;
+        type: string;
+        message: string;
+        closable: boolean;
+        buttonGroup: Component<ButtonGroupConfig>;
+      }
+    | undefined;
   private readonly factoryMetadata: FactoryMetadata | undefined;
 
   constructor({ options, factoryMetadata }: FlexLayoutParameters) {
@@ -47,6 +70,7 @@ export class FlexLayoutFactory implements ComponentFactory<FlexLayoutConfig> {
     if (options) {
       this.sections = options.sections;
       this.buttonGroup = options.buttonGroup;
+      this.alert = options.alert;
     }
   }
 
@@ -59,6 +83,7 @@ export class FlexLayoutFactory implements ComponentFactory<FlexLayoutConfig> {
       config: {
         ...(this.sections && { sections: this.sections }),
         ...(this.buttonGroup && { buttonGroup: this.buttonGroup }),
+        ...(this.alert && { alert: this.alert }),
       },
     };
   }

--- a/plugin/components/form-field.ts
+++ b/plugin/components/form-field.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// GENERATED: do not edit!
+
+import { ComponentFactory, FactoryMetadata } from './component-factory';
+import { Component } from './component';
+
+import { FormFieldConfig } from './form-field';
+
+export interface FormFieldConfig {
+  type: string;
+  label: string;
+  name: string;
+  value: any;
+  configuration?: {
+    choices?: {
+      label: string;
+      value: string;
+      checked: boolean;
+    }[];
+    multiple?: boolean;
+    fields?: Component<FormFieldConfig>[];
+  };
+  placeholder?: string;
+  error?: string;
+  validators?: { [key: component.FormValidator]: any };
+  width?: number;
+}
+
+export interface FormFieldOptions {
+  configuration?: {
+    choices?: {
+      label: string;
+      value: string;
+      checked: boolean;
+    }[];
+    multiple?: boolean;
+    fields?: Component<FormFieldConfig>[];
+  };
+  placeholder?: string;
+  error?: string;
+  validators?: { [key: component.FormValidator]: any };
+  width?: number;
+}
+
+interface FormFieldParameters {
+  type: string;
+  label: string;
+  name: string;
+  value: any;
+  options?: FormFieldOptions;
+  factoryMetadata?: FactoryMetadata;
+}
+
+export class FormFieldFactory implements ComponentFactory<FormFieldConfig> {
+  private readonly type: string;
+  private readonly label: string;
+  private readonly name: string;
+  private readonly value: any;
+  private readonly configuration:
+    | {
+        choices?: {
+          label: string;
+          value: string;
+          checked: boolean;
+        }[];
+        multiple?: boolean;
+        fields?: Component<FormFieldConfig>[];
+      }
+    | undefined;
+  private readonly placeholder: string | undefined;
+  private readonly error: string | undefined;
+  private readonly validators:
+    | { [key: component.FormValidator]: any }
+    | undefined;
+  private readonly width: number | undefined;
+  private readonly factoryMetadata: FactoryMetadata | undefined;
+
+  constructor({
+    type,
+    label,
+    name,
+    value,
+    options,
+    factoryMetadata,
+  }: FormFieldParameters) {
+    this.type = type;
+    this.label = label;
+    this.name = name;
+    this.value = value;
+    this.factoryMetadata = factoryMetadata;
+
+    if (options) {
+      this.configuration = options.configuration;
+      this.placeholder = options.placeholder;
+      this.error = options.error;
+      this.validators = options.validators;
+      this.width = options.width;
+    }
+  }
+
+  toComponent(): Component<FormFieldConfig> {
+    return {
+      metadata: {
+        type: 'formField',
+        ...this.factoryMetadata,
+      },
+      config: {
+        type: this.type,
+        label: this.label,
+        name: this.name,
+        value: this.value,
+
+        ...(this.configuration && { configuration: this.configuration }),
+        ...(this.placeholder && { placeholder: this.placeholder }),
+        ...(this.error && { error: this.error }),
+        ...(this.validators && { validators: this.validators }),
+        ...(this.width && { width: this.width }),
+      },
+    };
+  }
+}

--- a/plugin/components/json-editor.ts
+++ b/plugin/components/json-editor.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// GENERATED: do not edit!
+
+import { ComponentFactory, FactoryMetadata } from './component-factory';
+import { Component } from './component';
+
+export interface JSONEditorConfig {
+  mode: string;
+  content: string;
+}
+
+interface JSONEditorParameters {
+  mode: string;
+  content: string;
+  factoryMetadata?: FactoryMetadata;
+}
+
+export class JSONEditorFactory implements ComponentFactory<JSONEditorConfig> {
+  private readonly mode: string;
+  private readonly content: string;
+  private readonly factoryMetadata: FactoryMetadata | undefined;
+
+  constructor({ mode, content, factoryMetadata }: JSONEditorParameters) {
+    this.mode = mode;
+    this.content = content;
+    this.factoryMetadata = factoryMetadata;
+  }
+
+  toComponent(): Component<JSONEditorConfig> {
+    return {
+      metadata: {
+        type: 'jsonEditor',
+        ...this.factoryMetadata,
+      },
+      config: {
+        mode: this.mode,
+        content: this.content,
+      },
+    };
+  }
+}

--- a/plugin/components/label-selector.ts
+++ b/plugin/components/label-selector.ts
@@ -20,7 +20,8 @@ interface LabelSelectorParameters {
 }
 
 export class LabelSelectorFactory
-  implements ComponentFactory<LabelSelectorConfig> {
+  implements ComponentFactory<LabelSelectorConfig>
+{
   private readonly key: string;
   private readonly value: string;
   private readonly factoryMetadata: FactoryMetadata | undefined;

--- a/plugin/components/link.ts
+++ b/plugin/components/link.ts
@@ -13,11 +13,13 @@ export interface LinkConfig {
   ref: string;
   status?: number;
   statusDetail?: Component<any>;
+  component?: Component<any>;
 }
 
 export interface LinkOptions {
   status?: number;
   statusDetail?: Component<any>;
+  component?: Component<any>;
 }
 
 interface LinkParameters {
@@ -32,6 +34,7 @@ export class LinkFactory implements ComponentFactory<LinkConfig> {
   private readonly ref: string;
   private readonly status: number | undefined;
   private readonly statusDetail: Component<any> | undefined;
+  private readonly component: Component<any> | undefined;
   private readonly factoryMetadata: FactoryMetadata | undefined;
 
   constructor({ value, ref, options, factoryMetadata }: LinkParameters) {
@@ -42,6 +45,7 @@ export class LinkFactory implements ComponentFactory<LinkConfig> {
     if (options) {
       this.status = options.status;
       this.statusDetail = options.statusDetail;
+      this.component = options.component;
     }
   }
 
@@ -57,6 +61,7 @@ export class LinkFactory implements ComponentFactory<LinkConfig> {
 
         ...(this.status && { status: this.status }),
         ...(this.statusDetail && { statusDetail: this.statusDetail }),
+        ...(this.component && { component: this.component }),
       },
     };
   }

--- a/plugin/components/modal.ts
+++ b/plugin/components/modal.ts
@@ -10,11 +10,12 @@ import { Component } from './component';
 
 import { ButtonConfig } from './button';
 import { ButtonGroupConfig } from './button-group';
+import { FormFieldConfig } from './form-field';
 
 export interface ModalConfig {
   body?: Component<any>;
   form?: {
-    fields: any[];
+    fields: Component<FormFieldConfig>[];
     action?: string;
   };
   opened: boolean;
@@ -32,7 +33,7 @@ export interface ModalConfig {
 export interface ModalOptions {
   body?: Component<any>;
   form?: {
-    fields: any[];
+    fields: Component<FormFieldConfig>[];
     action?: string;
   };
   size?: string;
@@ -57,7 +58,7 @@ export class ModalFactory implements ComponentFactory<ModalConfig> {
   private readonly body: Component<any> | undefined;
   private readonly form:
     | {
-        fields: any[];
+        fields: Component<FormFieldConfig>[];
         action?: string;
       }
     | undefined;

--- a/plugin/components/modal.ts
+++ b/plugin/components/modal.ts
@@ -8,6 +8,9 @@
 import { ComponentFactory, FactoryMetadata } from './component-factory';
 import { Component } from './component';
 
+import { ButtonConfig } from './button';
+import { ButtonGroupConfig } from './button-group';
+
 export interface ModalConfig {
   body?: Component<any>;
   form?: {
@@ -16,15 +19,14 @@ export interface ModalConfig {
   };
   opened: boolean;
   size?: string;
-  buttons?: {
-    name: string;
-    payload: { [key: string]: any };
-    confirmation?: {
-      title: string;
-      body: string;
-    };
-    modal?: Component<any>;
-  }[];
+  buttons?: Component<ButtonConfig>[];
+  alert?: {
+    status: string;
+    type: string;
+    message: string;
+    closable: boolean;
+    buttonGroup: Component<ButtonGroupConfig>;
+  };
 }
 
 export interface ModalOptions {
@@ -34,15 +36,14 @@ export interface ModalOptions {
     action?: string;
   };
   size?: string;
-  buttons?: {
-    name: string;
-    payload: { [key: string]: any };
-    confirmation?: {
-      title: string;
-      body: string;
-    };
-    modal?: Component<any>;
-  }[];
+  buttons?: Component<ButtonConfig>[];
+  alert?: {
+    status: string;
+    type: string;
+    message: string;
+    closable: boolean;
+    buttonGroup: Component<ButtonGroupConfig>;
+  };
 }
 
 interface ModalParameters {
@@ -61,16 +62,15 @@ export class ModalFactory implements ComponentFactory<ModalConfig> {
       }
     | undefined;
   private readonly size: string | undefined;
-  private readonly buttons:
+  private readonly buttons: Component<ButtonConfig>[] | undefined;
+  private readonly alert:
     | {
-        name: string;
-        payload: { [key: string]: any };
-        confirmation?: {
-          title: string;
-          body: string;
-        };
-        modal?: Component<any>;
-      }[]
+        status: string;
+        type: string;
+        message: string;
+        closable: boolean;
+        buttonGroup: Component<ButtonGroupConfig>;
+      }
     | undefined;
   private readonly factoryMetadata: FactoryMetadata | undefined;
 
@@ -83,6 +83,7 @@ export class ModalFactory implements ComponentFactory<ModalConfig> {
       this.form = options.form;
       this.size = options.size;
       this.buttons = options.buttons;
+      this.alert = options.alert;
     }
   }
 
@@ -99,6 +100,7 @@ export class ModalFactory implements ComponentFactory<ModalConfig> {
         ...(this.form && { form: this.form }),
         ...(this.size && { size: this.size }),
         ...(this.buttons && { buttons: this.buttons }),
+        ...(this.alert && { alert: this.alert }),
       },
     };
   }

--- a/plugin/components/pod-status.ts
+++ b/plugin/components/pod-status.ts
@@ -12,6 +12,10 @@ export interface PodStatusConfig {
   pods?: {
     [key: string]: {
       details?: Component<any>[];
+      properties?: {
+        label?: string;
+        value?: Component<any>;
+      }[];
       status?: string;
     };
   };
@@ -21,6 +25,10 @@ export interface PodStatusOptions {
   pods?: {
     [key: string]: {
       details?: Component<any>[];
+      properties?: {
+        label?: string;
+        value?: Component<any>;
+      }[];
       status?: string;
     };
   };
@@ -36,6 +44,10 @@ export class PodStatusFactory implements ComponentFactory<PodStatusConfig> {
     | {
         [key: string]: {
           details?: Component<any>[];
+          properties?: {
+            label?: string;
+            value?: Component<any>;
+          }[];
           status?: string;
         };
       }

--- a/plugin/components/resource-viewer.ts
+++ b/plugin/components/resource-viewer.ts
@@ -56,7 +56,8 @@ interface ResourceViewerParameters {
 }
 
 export class ResourceViewerFactory
-  implements ComponentFactory<ResourceViewerConfig> {
+  implements ComponentFactory<ResourceViewerConfig>
+{
   private readonly edges:
     | {
         [key: string]: {

--- a/plugin/components/resource-viewer.ts
+++ b/plugin/components/resource-viewer.ts
@@ -24,6 +24,10 @@ export interface ResourceViewerConfig {
       kind?: string;
       status?: string;
       details?: Component<any>[];
+      properties?: {
+        label?: string;
+        value?: Component<any>;
+      }[];
       path?: Component<LinkConfig>;
     };
   };
@@ -44,6 +48,10 @@ export interface ResourceViewerOptions {
       kind?: string;
       status?: string;
       details?: Component<any>[];
+      properties?: {
+        label?: string;
+        value?: Component<any>;
+      }[];
       path?: Component<LinkConfig>;
     };
   };
@@ -74,6 +82,10 @@ export class ResourceViewerFactory
           kind?: string;
           status?: string;
           details?: Component<any>[];
+          properties?: {
+            label?: string;
+            value?: Component<any>;
+          }[];
           path?: Component<LinkConfig>;
         };
       }

--- a/plugin/components/signpost.ts
+++ b/plugin/components/signpost.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020 the Octant contributors. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// GENERATED: do not edit!
+
+import { ComponentFactory, FactoryMetadata } from './component-factory';
+import { Component } from './component';
+
+export interface SignpostConfig {
+  trigger: Component<any>;
+  message: string;
+  position: string;
+}
+
+interface SignpostParameters {
+  trigger: Component<any>;
+  message: string;
+  position: string;
+  factoryMetadata?: FactoryMetadata;
+}
+
+export class SignpostFactory implements ComponentFactory<SignpostConfig> {
+  private readonly trigger: Component<any>;
+  private readonly message: string;
+  private readonly position: string;
+  private readonly factoryMetadata: FactoryMetadata | undefined;
+
+  constructor({
+    trigger,
+    message,
+    position,
+    factoryMetadata,
+  }: SignpostParameters) {
+    this.trigger = trigger;
+    this.message = message;
+    this.position = position;
+    this.factoryMetadata = factoryMetadata;
+  }
+
+  toComponent(): Component<SignpostConfig> {
+    return {
+      metadata: {
+        type: 'signpost',
+        ...this.factoryMetadata,
+      },
+      config: {
+        trigger: this.trigger,
+        message: this.message,
+        position: this.position,
+      },
+    };
+  }
+}

--- a/plugin/components/stepper.ts
+++ b/plugin/components/stepper.ts
@@ -8,12 +8,14 @@
 import { ComponentFactory, FactoryMetadata } from './component-factory';
 import { Component } from './component';
 
+import { FormFieldConfig } from './form-field';
+
 export interface StepperConfig {
   action: string;
   steps: {
     name: string;
     form: {
-      fields: any[];
+      fields: Component<FormFieldConfig>[];
       action?: string;
     };
     title: string;
@@ -26,7 +28,7 @@ interface StepperParameters {
   steps: {
     name: string;
     form: {
-      fields: any[];
+      fields: Component<FormFieldConfig>[];
       action?: string;
     };
     title: string;
@@ -40,7 +42,7 @@ export class StepperFactory implements ComponentFactory<StepperConfig> {
   private readonly steps: {
     name: string;
     form: {
-      fields: any[];
+      fields: Component<FormFieldConfig>[];
       action?: string;
     };
     title: string;

--- a/plugin/components/summary.ts
+++ b/plugin/components/summary.ts
@@ -8,6 +8,8 @@
 import { ComponentFactory, FactoryMetadata } from './component-factory';
 import { Component } from './component';
 
+import { ButtonGroupConfig } from './button-group';
+
 export interface SummaryConfig {
   sections: {
     header: string;
@@ -23,8 +25,11 @@ export interface SummaryConfig {
     modal: boolean;
   }[];
   alert?: {
+    status: string;
     type: string;
     message: string;
+    closable: boolean;
+    buttonGroup: Component<ButtonGroupConfig>;
   };
 }
 
@@ -39,8 +44,11 @@ export interface SummaryOptions {
     modal: boolean;
   }[];
   alert?: {
+    status: string;
     type: string;
     message: string;
+    closable: boolean;
+    buttonGroup: Component<ButtonGroupConfig>;
   };
 }
 
@@ -71,8 +79,11 @@ export class SummaryFactory implements ComponentFactory<SummaryConfig> {
     | undefined;
   private readonly alert:
     | {
+        status: string;
         type: string;
         message: string;
+        closable: boolean;
+        buttonGroup: Component<ButtonGroupConfig>;
       }
     | undefined;
   private readonly factoryMetadata: FactoryMetadata | undefined;

--- a/plugin/components/summary.ts
+++ b/plugin/components/summary.ts
@@ -9,6 +9,7 @@ import { ComponentFactory, FactoryMetadata } from './component-factory';
 import { Component } from './component';
 
 import { ButtonGroupConfig } from './button-group';
+import { FormFieldConfig } from './form-field';
 
 export interface SummaryConfig {
   sections: {
@@ -19,7 +20,7 @@ export interface SummaryConfig {
     name: string;
     title: string;
     form: {
-      fields: any[];
+      fields: Component<FormFieldConfig>[];
       action?: string;
     };
     modal: boolean;
@@ -38,7 +39,7 @@ export interface SummaryOptions {
     name: string;
     title: string;
     form: {
-      fields: any[];
+      fields: Component<FormFieldConfig>[];
       action?: string;
     };
     modal: boolean;
@@ -71,7 +72,7 @@ export class SummaryFactory implements ComponentFactory<SummaryConfig> {
         name: string;
         title: string;
         form: {
-          fields: any[];
+          fields: Component<FormFieldConfig>[];
           action?: string;
         };
         modal: boolean;

--- a/plugin/components/text.ts
+++ b/plugin/components/text.ts
@@ -13,12 +13,14 @@ export interface TextConfig {
   isMarkdown?: boolean;
   trustedContent?: boolean;
   status?: number;
+  clipboardValue?: string;
 }
 
 export interface TextOptions {
   isMarkdown?: boolean;
   trustedContent?: boolean;
   status?: number;
+  clipboardValue?: string;
 }
 
 interface TextParameters {
@@ -32,6 +34,7 @@ export class TextFactory implements ComponentFactory<TextConfig> {
   private readonly isMarkdown: boolean | undefined;
   private readonly trustedContent: boolean | undefined;
   private readonly status: number | undefined;
+  private readonly clipboardValue: string | undefined;
   private readonly factoryMetadata: FactoryMetadata | undefined;
 
   constructor({ value, options, factoryMetadata }: TextParameters) {
@@ -42,6 +45,7 @@ export class TextFactory implements ComponentFactory<TextConfig> {
       this.isMarkdown = options.isMarkdown;
       this.trustedContent = options.trustedContent;
       this.status = options.status;
+      this.clipboardValue = options.clipboardValue;
     }
   }
 
@@ -57,6 +61,7 @@ export class TextFactory implements ComponentFactory<TextConfig> {
         ...(this.isMarkdown && { isMarkdown: this.isMarkdown }),
         ...(this.trustedContent && { trustedContent: this.trustedContent }),
         ...(this.status && { status: this.status }),
+        ...(this.clipboardValue && { clipboardValue: this.clipboardValue }),
       },
     };
   }

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-octant/plugin",
-  "version": "0.3.0",
+  "version": "0.21.0",
   "description": "TypeScript plugin library for Octant",
   "scripts": {
     "test": "jest",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-octant/plugin",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "TypeScript plugin library for Octant",
   "scripts": {
     "test": "jest",

--- a/yeoman-generator/package.json
+++ b/yeoman-generator/package.json
@@ -3,7 +3,7 @@
   "files": [
     "generators"
   ],
-  "version": "0.3.0",
+  "version": "0.21.0",
   "description": "A Yeoman generator for scaffolding an Octant Plugin in Typescript.",
   "keywords": [
     "octant",

--- a/yeoman-generator/package.json
+++ b/yeoman-generator/package.json
@@ -3,7 +3,7 @@
   "files": [
     "generators"
   ],
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "A Yeoman generator for scaffolding an Octant Plugin in Typescript.",
   "keywords": [
     "octant",


### PR DESCRIPTION
# NPM Version updates: 

* `plugin/package.json` updated from `0.2.2` to `0.21.0`
* `yeoman-generator/package.json` updated from `0.2.2` to `0.21.0`

There are issues with Yeoman pulling outdated code from NPM, leading to newly-created plugins not installing (see #20), so updating the version should result in future Yeoman generations to use correct code. Additionally, this PR adds more components to the plugin, generated by command in the main Octant repo ([reference](https://reference.octant.dev/?path=/docs/docs-hacking-3-generate-typescript-components--page)).

If/when this PR is merged in, the following commands might need to be run to publish the revised package versions to NPM:

* `npm publish` inside `./plugin`
* `npm publish` inside `./yeoman-generator`

## Potential testing steps

After publishing, 

1. Create and open a new directory on a local machine
2. Run `npm update -g @project-octant/generator-octant-plugin` to update the generator globally
3. Run `yo @project-octant/octant-plugin` to generate a new plugin with Yeoman
4. Run `npm run plugin:install` and verify that the project compiles on the first try

# Octant component update

As described above, the `go run ./cmd/ts-component-gen/main.go` was run to programmatically update the TS components in the `plugin/components` directory.

## Notes

~~Almost all components generated successfully, with the exception of `ExpandableRowDetail` ([source file](https://github.com/vmware-tanzu/octant/blob/2784bf528935ea3c35267865f8d4199fba696e8b/pkg/view/component/row_detail.go)); attempting to generate it threw the following error:~~

```
reflect154485806/reflect.go:91:27: undefined: component.ExpandableRowDetailConfig
```

~~Since generating this component would require changes to the main Octant repo, I left it out of the PR; if we decide that this component is necessary, maybe we could create another PR that addresses `ExpandableRowDetail` specifically. My main concern when making these changes was to update the plugin and the Yeoman generator so that users can build functional plugins without needing to edit pre-generated code.~~

This error has been resolved, please see the upstream PR [here](https://github.com/vmware-tanzu/octant/pull/2517).