### PR TITLE
Action to update generated components with cron job

### DIFF
--- a/.github/workflows/generate-components.yaml
+++ b/.github/workflows/generate-components.yaml
@@ -1,0 +1,40 @@
+name: Static TypeScript component update from main Octant repo
+on:
+  schedule: 
+  - cron: "0 0 * * *"
+
+jobs:
+  update-components:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Golang
+      uses: actions/setup-go@v2
+      with:
+        go-version: '^1.16.0'
+    - name: Install NodeJS
+      uses: actions/setup-node@v2
+      with: 
+        node-version: 14
+    - name: Install Prettier
+      run: npm i -g prettier
+    - name: Check out latest Octant code
+      uses: actions/checkout@master
+      with:
+        repository: vmware-tanzu/octant
+        path: octant
+    - name: Check out latest plugin library code
+      uses: actions/checkout@master
+      with:
+        path: plugin-library-for-octant
+    - name: Remove existing static TypeScript components
+      run: rm -rf ${{ github.workspace }}/plugin-library-for-octant/plugin/components
+    - name: Generate static TypeScript components
+      run: cd ./octant && go run ./cmd/ts-component-gen/main.go -dest ${{ github.workspace }}/plugin-library-for-octant/plugin/components
+    - name: Print out components in plugin lib
+      run: cd ${{ github.workspace }}/plugin-library-for-octant/plugin/components && ls
+    - name: Push changes to GitHub
+      uses: stefanzweifel/git-auto-commit-action@v4
+      if: steps.auto-commit-action.outputs.changes_detected == 'true'
+      with:
+        commit_message: Automatic update for generated TypeScript components
+        repository: ./plugin-library-for-octant

--- a/.github/workflows/generate-components.yaml
+++ b/.github/workflows/generate-components.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Install NodeJS
       uses: actions/setup-node@v2
       with: 
-        node-version: 14
+        node-version: 16
     - name: Install Prettier
       run: npm i -g prettier
     - name: Check out latest Octant code


### PR DESCRIPTION
This PR adds a GitHub Action that should run once every 24 hours; it will pull `vmware-tanzu/octant`, run [the command to automatically generate TypeScript components](https://reference.octant.dev/?path=/docs/docs-hacking-3-generate-typescript-components--page), and if the generated components differ from those previously generated, it will commit the newly regenerated components to this repo.

## Relevant issues:
* #23 
* https://github.com/vmware-tanzu/octant/issues/2525

## Testing changes:

This action is somewhat difficult to test; I ran into issues locally when trying to run the action within [act](https://github.com/nektos/act), and eventually gave up and just tested the action on my fork. 

If testing on a fork, please replace `vmware-tanzu/octant` on line 23 in `update-components.yaml` with a path to your Octant fork; changing the trigger from a cron job to a more replicable event (e.g. push) will be useful too.