### PR TITLE
Fixes issue with component generating GitHub Action not completing

### DIFF
--- a/.github/workflows/generate-components.yaml
+++ b/.github/workflows/generate-components.yaml
@@ -34,7 +34,6 @@ jobs:
       run: cd ${{ github.workspace }}/plugin-library-for-octant/plugin/components && ls
     - name: Push changes to GitHub
       uses: stefanzweifel/git-auto-commit-action@v4
-      if: steps.auto-commit-action.outputs.changes_detected == 'true'
       with:
         commit_message: Automatic update for generated TypeScript components
         repository: ./plugin-library-for-octant


### PR DESCRIPTION
There is an error in current previous implementation of the component generating GitHub Action; it attempts to check whether the newly autogenerated components differ from the current ones before committing to Git, but this check always returns false, meaning that no changes are ever committed.

This PR removes that unnecessary check; if the autogenerated files have not changed, Git will simply assert that there are no changes to commit, and the action finishes without issues:

```
Run stefanzweifel/git-auto-commit-action@v4
Started: bash /home/runner/work/_actions/stefanzweifel/git-auto-commit-action/v4/entrypoint.sh
INPUT_REPOSITORY value: ./plugin-library-for-octant
INPUT_STATUS_OPTIONS: 
Working tree clean. Nothing to commit.
```

However, if the autogenerated files have changed, they will be committed accordingly, and the Action functions as intended.