### PR TITLE
Increments versions to match Octant

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-octant/plugin",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "TypeScript plugin library for Octant",
   "scripts": {
     "test": "jest",

--- a/yeoman-generator/generators/app/templates/package.json.tpl
+++ b/yeoman-generator/generators/app/templates/package.json.tpl
@@ -42,7 +42,7 @@
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {
-    "@project-octant/plugin": "^0.2.2",
+    "@project-octant/plugin": "^0.22.0",
     "@kubernetes/client-node": "^0.12.0",
     "regenerator-runtime": "^0.13.5",
     "route-recognizer": "^0.3.4",

--- a/yeoman-generator/package.json
+++ b/yeoman-generator/package.json
@@ -3,7 +3,7 @@
   "files": [
     "generators"
   ],
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "A Yeoman generator for scaffolding an Octant Plugin in Typescript.",
   "keywords": [
     "octant",


### PR DESCRIPTION
Bumps the `@project-octant/plugin` version to `0.22.0` to match Octant's latest release. Accordingly, the version for the `plugin` dependency in `@project-octant/generator` is increased to `0.22.0`, and thus `generator` is incremented to `0.22.0` as well.

Signed-off-by: Liam Rathke <lrathke@vmware.com>