### PR TITLE
escape backslash for windows path

### DIFF
--- a/yeoman-generator/generators/app/index.js
+++ b/yeoman-generator/generators/app/index.js
@@ -30,7 +30,7 @@ module.exports = class extends Generator {
                 type: 'input',
                 name: 'pluginPath',
                 message: 'Octant plugin path: ',
-                default: os.homedir() + '/.config/octant/plugins'
+                default: os.homedir().replace(/\\/g, '\\\\') + '/.config/octant/plugins'
             }
         ];
 

--- a/yeoman-generator/generators/app/templates/package.json.tpl
+++ b/yeoman-generator/generators/app/templates/package.json.tpl
@@ -9,10 +9,10 @@
   "scripts": {
     "plugin:check": "tsc --noEmit",
     "plugin:watch": "npx tsc-watch --noEmit --onSuccess \"npm run plugin:dev-no-check\"",
-    "plugin:dev-no-check": "webpack --output <%= pluginPath %>/<%= filename %>.js",
-    "plugin:dev": "tsc --noEmit && webpack --output <%= pluginPath %>/<%= filename %>.js",
+    "plugin:dev-no-check": "webpack --output <%= pluginPath.replace(/\\/g, '\\\\') %>/<%= filename %>.js",
+    "plugin:dev": "tsc --noEmit && webpack --output <%= pluginPath.replace(/\\/g, '\\\\') %>/<%= filename %>.js",
     "plugin:prod": "tsc --noEmit && webpack --env=production --output dist/<%= filename %>.js",
-    "plugin:install": "tsc --noEmit && webpack --env=production --output <%= pluginPath %>/<%= filename %>.js"
+    "plugin:install": "tsc --noEmit && webpack --env=production --output <%= pluginPath.replace(/\\/g, '\\\\') %>/<%= filename %>.js"
   },
   "keywords": [
     "octant",


### PR DESCRIPTION
Yeoman template generation currently prints unescaped backslashes inside a plugin directory path which are pretty common on windows. This causes yeoman process to fail as rendering the backslashes as-is breaks the rendered package.json file causing the following error:
```? Your plugin name:  test
? Your plugin description:  test
? Octant plugin path:  C:\Users\vikram/.config/octant/plugins
   create package.json
   create src\test.ts
   create src\routes.ts
   create src\content.ts
   create webpack.config.js
   create tsconfig.json


I'm all done. Running npm install for you to install the required dependencies. If this fails, try running the command yourself.


npm ERR! code EJSONPARSE
npm ERR! file C:\Users\vikram\workspace\octant-plugins\js\test\package.json
npm ERR! JSON.parse Failed to parse json
npm ERR! JSON.parse Unexpected token U in JSON at position 326 while parsing near '...webpack --output C:\Users\vikram/.config...'
npm ERR! JSON.parse Failed to parse package.json data.
npm ERR! JSON.parse package.json must be actual JSON, not just JavaScript.
```

The solution is to escape the backslashes for windows path such that valid strings are rendered inside package.json.